### PR TITLE
Add note HTML sync and listing

### DIFF
--- a/.github/workflows/post.yml
+++ b/.github/workflows/post.yml
@@ -8,23 +8,35 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: clone blog-article
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: taiseimiyaji/blog_article
           path: blog_article
           token: ${{ secrets.COPY_ACCESS_TOKEN }}
       - name: delete article
         run: rm -rf src/content/blog/Article
+      - name: delete note
+        run: rm -rf public/note
       - name: create folder
         run: mkdir -p src/content/blog/Article
+      - name: create note folder
+        run: mkdir -p public/note
       - name: create images folder
         run: mkdir -p public/images
       - name: copy article
-        run: cp -n -r blog_article/Article/* src/content/blog/Article
+        run: rsync -a --exclude 'note/' blog_article/Article/ src/content/blog/Article/
+      - name: copy note
+        run: |
+          if [ -d blog_article/Article/note ]; then
+            rsync -a --include '*/' --include '*.html' --exclude '*' blog_article/Article/note/ public/note/
+          fi
       - name: copy images
-        run: cp -r blog_article/images/* public/images
+        run: |
+          if [ -d blog_article/images ]; then
+            cp -r blog_article/images/. public/images/
+          fi
       - name: clean repository
         run: rm -rf blog_article
       - name: npm install
@@ -32,12 +44,12 @@ jobs:
       - name: build
         run: npm run build
       - name: create pr
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.COPY_ACCESS_TOKEN }}
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-          commit-message: 'copy Articles'
-          branch: copy_Articles
+          commit-message: 'copy Articles and notes'
+          branch: copy_Articles_and_notes
           branch-suffix: timestamp
           delete-branch: true
-          title: 'updated Articles'
+          title: 'updated Articles and notes'

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -8,7 +8,10 @@ export default function Header() {
 			</div>
 			<div className="header-link">
 				<a href="/">
-					<div> Blog</div>
+					<div>Blog</div>
+				</a>
+				<a href="/note">
+					<div>Note</div>
 				</a>
 				<a href="/profile">
 					<div>Profile</div>

--- a/src/pages/note/index.astro
+++ b/src/pages/note/index.astro
@@ -1,0 +1,99 @@
+---
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import Header from "../../components/Header/Header";
+import Footer from "../../components/Footer/Footer";
+import "../../styles/index.scss";
+
+type NoteEntry = {
+	title: string;
+	date: string;
+	href: string;
+};
+
+const noteRoot = fileURLToPath(new URL("../../../public/note", import.meta.url));
+
+function findHtmlFiles(directory: string): string[] {
+	if (!existsSync(directory)) {
+		return [];
+	}
+
+	return readdirSync(directory)
+		.flatMap((name) => {
+			const path = `${directory}/${name}`;
+			const stat = statSync(path);
+			if (stat.isDirectory()) {
+				return findHtmlFiles(path);
+			}
+			return path.endsWith(".html") ? [path] : [];
+		});
+}
+
+function getCommentValue(html: string, key: string): string | undefined {
+	const comments = [...html.matchAll(/<!--([\s\S]*?)-->/g)].map((match) => match[1]);
+	const pattern = new RegExp(`^\\s*${key}\\s*:\\s*(.+?)\\s*$`, "im");
+	for (const comment of comments) {
+		const value = comment.match(pattern)?.[1]?.trim();
+		if (value) {
+			return value;
+		}
+	}
+	return undefined;
+}
+
+function getTitle(html: string, filePath: string): string {
+	return (
+		getCommentValue(html, "title") ??
+		html.match(/<title[^>]*>(.*?)<\/title>/i)?.[1]?.trim() ??
+		filePath.split("/").pop()?.replace(/\.html$/, "") ??
+		"Untitled"
+	);
+}
+
+function getDate(html: string, relativePath: string): string {
+	return (
+		getCommentValue(html, "date") ??
+		relativePath.match(/\d{4}-\d{2}-\d{2}/)?.[0] ??
+		relativePath.match(/(\d{4})\/(\d{2})\/(\d{2})/)?.slice(1, 4).join("-") ??
+		""
+	);
+}
+
+const notes: NoteEntry[] = findHtmlFiles(noteRoot)
+	.map((filePath) => {
+		const relativePath = filePath.replace(`${noteRoot}/`, "");
+		const html = readFileSync(filePath, "utf-8");
+		return {
+			title: getTitle(html, filePath),
+			date: getDate(html, relativePath),
+			href: `/note/${relativePath}`,
+		};
+	})
+	.sort((a, b) => b.date.localeCompare(a.date));
+---
+<html lang="ja">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+		<meta name="description" content="note形式の記事一覧です。" />
+		<title>Note | Lyricrime.com</title>
+	</head>
+	<body>
+		<main>
+			<Header />
+			<div class="content">
+				<div class="card-list">
+					{notes.map((note) => (
+						<a href={note.href}>
+							<div class="card">
+								{note.date && <div class="date">{note.date.replaceAll("-", "/")}</div>}
+								<div class="title">{note.title}</div>
+							</div>
+						</a>
+					))}
+				</div>
+			</div>
+			<Footer />
+		</main>
+	</body>
+</html>


### PR DESCRIPTION
## Summary
- sync note HTML files from blog_article into public/note via repository_dispatch workflow
- add /note/ listing page that reads public/note/**/*.html metadata
- add Note to the header navigation

## Verification
- npm run build
- npx biome lint src/components/Header/Header.tsx src/pages/note/index.astro
- checked Blog / Note / Profile nav and /note/ page with Playwright